### PR TITLE
fix(security): enable KMS encryption on unencrypted my_app_data S3 bucket

### DIFF
--- a/hdsproto/terraform/aws/s3.tf
+++ b/hdsproto/terraform/aws/s3.tf
@@ -8,6 +8,21 @@ resource "aws_s3_bucket" "my_app_data" {
   })
 }
 
+# REMEDIATION: Enable KMS encryption for my_app_data bucket
+# Detected: S3 bucket has no server-side encryption configured
+# Risk: Data at rest is unencrypted, violating security compliance requirements
+resource "aws_s3_bucket_server_side_encryption_configuration" "my_app_data" {
+  bucket = aws_s3_bucket.my_app_data.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm     = "aws:kms"
+      kms_master_key_id = aws_kms_key.s3_encryption.arn
+    }
+    bucket_key_enabled = true
+  }
+}
+
 # S3 bucket for application data
 resource "aws_s3_bucket" "app_data" {
   bucket = "${var.project_name}-app-data-${var.environment}"


### PR DESCRIPTION
**Generated by:** terraform-remediation-agent-b8e4c1d9
**Labels:** security-scan, automated-fix, terraform

---

## What was corrected

This PR remediates a security misconfiguration detected during an automated compliance scan. The following issue was identified and corrected:

- **Unencrypted S3 Bucket**: `my_app_data` bucket had no server-side encryption configured, leaving data at rest unprotected

## Why this change was made

A security compliance scan detected that the `my_app_data` S3 bucket was created without server-side encryption. Unencrypted S3 buckets violate:

1. **AWS Security Best Practices** - All S3 buckets should have encryption enabled by default
2. **Data Protection Compliance** - Data at rest must be encrypted to meet regulatory requirements (SOC 2, HIPAA, PCI-DSS)
3. **Organization Security Policy** - All storage resources must use KMS encryption with customer-managed keys
4. **CIS AWS Benchmark 2.1.1** - Ensure S3 Bucket Encryption is Enabled

The misconfiguration likely occurred because the bucket was provisioned without referencing the existing encryption patterns used by other S3 buckets in this workspace (`app_data`, `user_uploads`, `app_logs`).

## Security Analysis

### Impact Assessment

- **Risk Level**: High
- **Severity**: Critical - data at rest is unencrypted
- **Resources Affected**: 1 (`aws_s3_bucket.my_app_data`)
- **Breaking Changes**: None - adding encryption to an existing bucket is non-disruptive
- **Rollback Plan**: Remove the `aws_s3_bucket_server_side_encryption_configuration` resource

### Technical Details

**Unencrypted S3 Bucket:**
- Detected: `my_app_data` bucket has no `aws_s3_bucket_server_side_encryption_configuration` resource
- Root Cause: Bucket was provisioned without encryption configuration, unlike peer buckets in the same workspace
- Fix: Added `aws_s3_bucket_server_side_encryption_configuration.my_app_data` with KMS encryption
- Encryption Algorithm: `aws:kms` (customer-managed key via `aws_kms_key.s3_encryption`)
- Bucket Key: Enabled to reduce KMS API costs

**Why KMS over AES256:**
- Customer-managed keys provide granular access control via KMS key policies
- Enables audit logging of encryption/decryption operations via CloudTrail
- Allows key rotation management
- Consistent with encryption configuration of all other S3 buckets in this workspace

## Remediation Checklist

| Resource | Issue Found | Remediation Applied | Status |
|----------|-------------|---------------------|--------|
| `my_app_data` S3 bucket | No server-side encryption configured | Added `aws_s3_bucket_server_side_encryption_configuration` with KMS | ✅ Complete |

## Testing & Validation

- ✅ `terraform plan` executed successfully - 1 resource to add, 0 to change, 0 to destroy
- ✅ No breaking changes detected - encryption is applied to new objects; existing objects remain accessible
- ✅ KMS key `aws_kms_key.s3_encryption` already exists and is referenced by other bucket encryption configs
- ✅ Bucket key enabled to minimize KMS API costs
- ✅ Configuration matches encryption pattern used by `app_data`, `user_uploads`, and `app_logs` buckets

### Terraform Plan Summary

```
Plan: 1 to add, 0 to change, 0 to destroy.

Changes:
  + aws_s3_bucket_server_side_encryption_configuration.my_app_data
```

## Additional Context

- **Detection Tool**: HCP Terraform Security Scan
- **Detection Time**: 2026-05-05 19:42:31 UTC
- **Affected Workspace**: `terraform-remediation-demo`
- **Terraform Version**: 1.7.0
- **AWS Provider Version**: 5.38.0
- **CIS Benchmark Rule**: 2.1.1 - Ensure S3 Bucket Encryption is Enabled

### Related Documentation
- [AWS S3 Default Encryption](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucket-encryption.html)
- [Terraform aws_s3_bucket_server_side_encryption_configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration)
- [AWS KMS Best Practices](https://docs.aws.amazon.com/kms/latest/developerguide/best-practices.html)
- [CIS AWS Foundations Benchmark](https://www.cisecurity.org/benchmark/amazon_web_services)

---

**Review Notes:**
- Single-resource remediation targeting the only unencrypted S3 bucket in the workspace
- Uses the same KMS key already provisioned for other bucket encryption configurations
- No destructive operations - only adding encryption configuration
- Existing unencrypted objects will NOT be retroactively encrypted (standard AWS behavior)
- Recommended action: Approve, merge, then verify encryption status in AWS Console